### PR TITLE
Move ring out of project dependencies.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "http://github.com/pjlegato/ring.middleware.conditional"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [ring "1.3.1"]]
-  :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]}})
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :profiles {:dev {:dependencies [[ring "1.3.1"]
+                                  [ring-mock "0.1.5"]]}})


### PR DESCRIPTION
Hello,

Thought `ring.middleware.conditional` could do without the weight of the `ring` dependency when including it in other projects. Propose moving it into dev profile.
