### PR TITLE
Add refer-clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "http://github.com/pjlegato/ring.middleware.conditional"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [ring "1.3.1"]]
-  :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]}})
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [ring/ring-core "1.7.1"]]
+  :profiles {:dev {:dependencies [[ring/ring-mock "0.4.0"]]}})

--- a/src/ring/middleware/conditional.clj
+++ b/src/ring/middleware/conditional.clj
@@ -1,6 +1,7 @@
 (ns ring.middleware.conditional
   "Conditional Ring middleware, which allows conditional execution
-   of Ring middleware paths. Includes convenience methods for common cases.")
+   of Ring middleware paths. Includes convenience methods for common cases."
+  (:refer-clojure :exclude [if]))
 
 
 (defn if


### PR DESCRIPTION
Add `refer-clojure` to prevent name conflict and bump version to work with current Leiningen.